### PR TITLE
Split lib into modules and make parser pure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,72 @@ use std::collections::BTreeSet as Set;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+pub fn run(root_path: impl AsRef<Path>, emitter: &mut Emitter) -> Result<(), Error> {
+    run_(root_path.as_ref(), emitter)
+}
+
+fn run_(root_path: &Path, emitter: &mut Emitter) -> Result<(), Error> {
+    let mut files = Map::new();
+
+    for entry in WalkDir::new(root_path) {
+        let entry = entry.context("traversing")?;
+        if entry.path().to_str().unwrap_or("").contains("_Old_Tests") {
+            continue;
+        }
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("ps1") {
+            continue;
+        }
+
+        match parse_and_preprocess(entry.path(), emitter)? {
+            PreprocessOutput::Valid(parsed) => {
+                let path = entry.path().canonicalize()?;
+                files.insert(path, parsed);
+            }
+            PreprocessOutput::InvalidImports => {
+                eprintln!(
+                    "Stopping analysis for this file because of import errors: {}\n",
+                    entry.path().display()
+                );
+            }
+        };
+    }
+
+    analyze(&files, emitter).context("analyzing")?;
+
+    Ok(())
+}
+
+fn is_allowed(line: &str, what: &str) -> bool {
+    let mut chunks = line.splitn(2, "#");
+
+    match chunks.next() {
+        Some(_before_comment) => (),
+        None => return false,
+    }
+
+    match chunks.next() {
+        Some(comment) => comment.to_lowercase().contains("allow") && comment.contains(what),
+        None => false,
+    }
+}
+
+/// Kind of error message
+#[derive(Debug)]
+pub enum Message {
+    Error,
+    Warning,
+}
+
+impl Default for Message {
+    fn default() -> Message { Message::Error }
+}
+
 pub use syntax::Line;
 
+/// Location of a message
 #[derive(Default, Debug)]
 pub struct Location {
     pub file: PathBuf,
@@ -32,17 +96,6 @@ impl Line {
             file: file.to_owned(),
         }
     }
-}
-
-/// Parsed and preprocessed source file
-#[derive(Debug)]
-struct Parsed {
-    imports: Vec<PathBuf>,
-    definitions: Vec<syntax::Definition>,
-    usages: Vec<syntax::Usage>,
-
-    /// Original, non-resolved path, relative to PWD
-    original_path: PathBuf,
 }
 
 pub trait Emitter {
@@ -86,206 +139,17 @@ impl Emitter for VecEmitter {
     }
 }
 
-pub fn run(root_path: impl AsRef<Path>, emitter: &mut Emitter) -> Result<(), Error> {
-    run_(root_path.as_ref(), emitter)
-}
+// ---- Preprocessing --------------------------------------------------------
 
-pub fn run_(root_path: &Path, emitter: &mut Emitter) -> Result<(), Error> {
-    let mut files = Map::new();
-
-    for entry in WalkDir::new(root_path) {
-        let entry = entry.context("traversing")?;
-        if entry.path().to_str().unwrap_or("").contains("_Old_Tests") {
-            continue;
-        }
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        if entry.path().extension().and_then(|ext| ext.to_str()) != Some("ps1") {
-            continue;
-        }
-
-        match parse_and_preprocess(entry.path(), emitter)? {
-            PreprocessOutput::Valid(parsed) => {
-                let path = entry.path().canonicalize()?;
-                files.insert(path, parsed);
-            }
-            PreprocessOutput::InvalidImports => {
-                eprintln!(
-                    "Stopping analysis for this file because of import errors: {}\n",
-                    entry.path().display()
-                );
-            }
-        };
-    }
-
-    analyze(&files, emitter).context("analyzing")?;
-
-    Ok(())
-}
-
-/// Functions in scope
-#[derive(Debug, Clone, Default)]
-struct Scope<'a> {
-    /// Functions defined in this scopeanalyze
-    defined: Set<&'a str>,
-    /// Defined by a file imported by `analyze
-    directly_imported: Set<&'a str>,
-    /// All the functions in scope
-    all: Set<&'a str>,
-    /// All the files imported (directlanalyzely)
-    files: Set<&'a Path>,
-}
-
-/// Type of function found in scope
+/// Parsed and preprocessed source file
 #[derive(Debug)]
-enum Found {
-    /// Found in Scope::defined or Scope::indirectly_imported
-    Direct,
-    /// Indirectly imported (through multiple layers of `.`)
-    Indirect,
-}
+struct Parsed {
+    imports: Vec<PathBuf>,
+    definitions: Vec<syntax::Definition>,
+    usages: Vec<syntax::Usage>,
 
-impl<'a> Scope<'a> {
-    fn search(&self, name: &str) -> Option<Found> {
-        if self.all.contains(name) {
-            if self.defined.contains(name) || self.directly_imported.contains(name) {
-                Some(Found::Direct)
-            } else {
-                Some(Found::Indirect)
-            }
-        } else {
-            None
-        }
-    }
-}
-
-/// State of scope computation
-#[derive(Debug, Clone)]
-enum ScopeWip<'a> {
-    /// Done
-    Resolved(Scope<'a>),
-
-    /// The scope is being currently computed
-    /// (used to detect import loop)
-    Current,
-}
-
-fn analyze(files: &Map<PathBuf, Parsed>, emitter: &mut Emitter) -> Result<(), Error> {
-    lazy_static! {
-        static ref BUILTINS: Set<&'static str> = include_str!("builtins.txt")
-            .split_whitespace()
-            .chain(include_str!("extras.txt").split_whitespace())
-            .collect();
-    }
-
-    let mut scopes = Map::new();
-
-    for path in files.keys() {
-        let scope = get_scope(path, files, &mut scopes)?;
-
-        let parsed = &files[path];
-
-        let mut already_analyzed = Set::new();
-
-        for usage in &parsed.usages {
-            if BUILTINS.contains(usage.name.as_str()) {
-                continue;
-            }
-            if is_allowed(&usage.location.line, &usage.name) {
-                continue;
-            }
-            if already_analyzed.contains(usage.name.as_str()) {
-                continue;
-            }
-
-            already_analyzed.insert(usage.name.as_str());
-
-            match scope.search(&usage.name) {
-                None => emitter.emit(
-                    Message::Error,
-                    format!("Not in scope: {}", usage.name),
-                    usage.location.in_file(&parsed.original_path),
-                    None,
-                ),
-                Some(Found::Indirect) => emitter.emit(
-                    Message::Warning,
-                    format!("Indirectly imported: {}", usage.name),
-                    usage.location.in_file(&parsed.original_path),
-                    None,
-                ),
-                _ => (),
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn is_allowed(line: &str, what: &str) -> bool {
-    let mut chunks = line.splitn(2, "#");
-
-    match chunks.next() {
-        Some(_before_comment) => (),
-        None => return false,
-    }
-
-    match chunks.next() {
-        Some(comment) => comment.to_lowercase().contains("allow") && comment.contains(what),
-        None => false,
-    }
-}
-
-fn get_scope<'a>(
-    file: &'a Path,
-    files: &'a Map<PathBuf, Parsed>,
-    scopes: &mut Map<&'a Path, ScopeWip<'a>>,
-) -> Result<Scope<'a>, Error> {
-    match scopes.get(file) {
-        Some(ScopeWip::Current) => bail!("Recursive import of {}", file.display()),
-        Some(ScopeWip::Resolved(scope)) => return Ok(scope.clone()),
-        _ => (),
-    };
-    scopes.insert(file, ScopeWip::Current);
-
-    let parsed_file = files.get(file).ok_or_else(|| {
-        format_err!(
-            "List of elements in scope of file {} was requested, \
-             but not available due to previous import error",
-            file.display()
-        )
-    })?;
-
-    let mut scope = Scope::default();
-
-    for import in &parsed_file.imports {
-        let nested = get_scope(&import, files, scopes)?;
-        scope.directly_imported.extend(&nested.defined);
-        scope.all.extend(&nested.all);
-        scope.files.extend(&nested.files);
-    }
-
-    for definition in &parsed_file.definitions {
-        scope.defined.insert(&definition.name);
-        scope.all.insert(&definition.name);
-    }
-
-    scope.files.insert(file);
-
-    scopes.insert(file, ScopeWip::Resolved(scope.clone()));
-
-    Ok(scope)
-}
-
-/// Kind of error message
-#[derive(Debug)]
-pub enum Message {
-    Error,
-    Warning,
-}
-
-impl Default for Message {
-    fn default() -> Message { Message::Error }
+    /// Original, non-resolved path, relative to PWD
+    original_path: PathBuf,
 }
 
 #[derive(Debug)]
@@ -392,4 +256,145 @@ fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &m
     }
 
     Ok(Some(resolved_imports))
+}
+
+// ---- Scope analysis -------------------------------------------------------
+
+/// Functions in scope
+#[derive(Debug, Clone, Default)]
+struct Scope<'a> {
+    /// Functions defined in this scopeanalyze
+    defined: Set<&'a str>,
+    /// Defined by a file imported by `analyze
+    directly_imported: Set<&'a str>,
+    /// All the functions in scope
+    all: Set<&'a str>,
+    /// All the files imported (directlanalyzely)
+    files: Set<&'a Path>,
+}
+
+/// Type of function found in scope
+#[derive(Debug)]
+enum Found {
+    /// Found in Scope::defined or Scope::indirectly_imported
+    Direct,
+    /// Indirectly imported (through multiple layers of `.`)
+    Indirect,
+}
+
+impl<'a> Scope<'a> {
+    fn search(&self, name: &str) -> Option<Found> {
+        if self.all.contains(name) {
+            if self.defined.contains(name) || self.directly_imported.contains(name) {
+                Some(Found::Direct)
+            } else {
+                Some(Found::Indirect)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// State of scope computation
+#[derive(Debug, Clone)]
+enum ScopeWip<'a> {
+    /// Done
+    Resolved(Scope<'a>),
+
+    /// The scope is being currently computed
+    /// (used to detect import loop)
+    Current,
+}
+
+fn analyze(files: &Map<PathBuf, Parsed>, emitter: &mut Emitter) -> Result<(), Error> {
+    lazy_static! {
+        static ref BUILTINS: Set<&'static str> = include_str!("builtins.txt")
+            .split_whitespace()
+            .chain(include_str!("extras.txt").split_whitespace())
+            .collect();
+    }
+
+    let mut scopes = Map::new();
+
+    for path in files.keys() {
+        let scope = get_scope(path, files, &mut scopes)?;
+
+        let parsed = &files[path];
+
+        let mut already_analyzed = Set::new();
+
+        for usage in &parsed.usages {
+            if BUILTINS.contains(usage.name.as_str()) {
+                continue;
+            }
+            if is_allowed(&usage.location.line, &usage.name) {
+                continue;
+            }
+            if already_analyzed.contains(usage.name.as_str()) {
+                continue;
+            }
+
+            already_analyzed.insert(usage.name.as_str());
+
+            match scope.search(&usage.name) {
+                None => emitter.emit(
+                    Message::Error,
+                    format!("Not in scope: {}", usage.name),
+                    usage.location.in_file(&parsed.original_path),
+                    None,
+                ),
+                Some(Found::Indirect) => emitter.emit(
+                    Message::Warning,
+                    format!("Indirectly imported: {}", usage.name),
+                    usage.location.in_file(&parsed.original_path),
+                    None,
+                ),
+                _ => (),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_scope<'a>(
+    file: &'a Path,
+    files: &'a Map<PathBuf, Parsed>,
+    scopes: &mut Map<&'a Path, ScopeWip<'a>>,
+) -> Result<Scope<'a>, Error> {
+    match scopes.get(file) {
+        Some(ScopeWip::Current) => bail!("Recursive import of {}", file.display()),
+        Some(ScopeWip::Resolved(scope)) => return Ok(scope.clone()),
+        _ => (),
+    };
+    scopes.insert(file, ScopeWip::Current);
+
+    let parsed_file = files.get(file).ok_or_else(|| {
+        format_err!(
+            "List of elements in scope of file {} was requested, \
+             but not available due to previous import error",
+            file.display()
+        )
+    })?;
+
+    let mut scope = Scope::default();
+
+    for import in &parsed_file.imports {
+        let nested = get_scope(&import, files, scopes)?;
+        scope.directly_imported.extend(&nested.defined);
+        scope.all.extend(&nested.all);
+        scope.files.extend(&nested.files);
+    }
+
+    for definition in &parsed_file.definitions {
+        scope.defined.insert(&definition.name);
+        scope.all.insert(&definition.name);
+    }
+
+    scope.files.insert(file);
+
+    scopes.insert(file, ScopeWip::Resolved(scope.clone()));
+
+    Ok(scope)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate lazy_static;
 
 mod syntax;
 mod preprocess;
+mod scope;
 
 use walkdir::WalkDir;
 
@@ -14,10 +15,7 @@ use failure::Error;
 use failure::ResultExt;
 
 use std::collections::BTreeMap as Map;
-use std::collections::BTreeSet as Set;
 use std::path::{Path, PathBuf};
-
-use preprocess::Parsed;
 
 pub fn run(root_path: impl AsRef<Path>, emitter: &mut Emitter) -> Result<(), Error> {
     run_(root_path.as_ref(), emitter)
@@ -54,7 +52,7 @@ fn run_(root_path: &Path, emitter: &mut Emitter) -> Result<(), Error> {
         };
     }
 
-    analyze(&files, emitter).context("analyzing")?;
+    scope::analyze(&files, emitter).context("analyzing")?;
 
     Ok(())
 }
@@ -141,145 +139,4 @@ impl Emitter for VecEmitter {
         let to_emit = EmittedItem { kind, message, location, notes };
         self.emitted_items.push(to_emit)
     }
-}
-
-// ---- Scope analysis -------------------------------------------------------
-
-/// Functions in scope
-#[derive(Debug, Clone, Default)]
-struct Scope<'a> {
-    /// Functions defined in this scopeanalyze
-    defined: Set<&'a str>,
-    /// Defined by a file imported by `analyze
-    directly_imported: Set<&'a str>,
-    /// All the functions in scope
-    all: Set<&'a str>,
-    /// All the files imported (directlanalyzely)
-    files: Set<&'a Path>,
-}
-
-/// Type of function found in scope
-#[derive(Debug)]
-enum Found {
-    /// Found in Scope::defined or Scope::indirectly_imported
-    Direct,
-    /// Indirectly imported (through multiple layers of `.`)
-    Indirect,
-}
-
-impl<'a> Scope<'a> {
-    fn search(&self, name: &str) -> Option<Found> {
-        if self.all.contains(name) {
-            if self.defined.contains(name) || self.directly_imported.contains(name) {
-                Some(Found::Direct)
-            } else {
-                Some(Found::Indirect)
-            }
-        } else {
-            None
-        }
-    }
-}
-
-/// State of scope computation
-#[derive(Debug, Clone)]
-enum ScopeWip<'a> {
-    /// Done
-    Resolved(Scope<'a>),
-
-    /// The scope is being currently computed
-    /// (used to detect import loop)
-    Current,
-}
-
-fn analyze(files: &Map<PathBuf, Parsed>, emitter: &mut Emitter) -> Result<(), Error> {
-    lazy_static! {
-        static ref BUILTINS: Set<&'static str> = include_str!("builtins.txt")
-            .split_whitespace()
-            .chain(include_str!("extras.txt").split_whitespace())
-            .collect();
-    }
-
-    let mut scopes = Map::new();
-
-    for path in files.keys() {
-        let scope = get_scope(path, files, &mut scopes)?;
-
-        let parsed = &files[path];
-
-        let mut already_analyzed = Set::new();
-
-        for usage in &parsed.usages {
-            if BUILTINS.contains(usage.name.as_str()) {
-                continue;
-            }
-            if is_allowed(&usage.location.line, &usage.name) {
-                continue;
-            }
-            if already_analyzed.contains(usage.name.as_str()) {
-                continue;
-            }
-
-            already_analyzed.insert(usage.name.as_str());
-
-            match scope.search(&usage.name) {
-                None => emitter.emit(
-                    Message::Error,
-                    format!("Not in scope: {}", usage.name),
-                    usage.location.in_file(&parsed.original_path),
-                    None,
-                ),
-                Some(Found::Indirect) => emitter.emit(
-                    Message::Warning,
-                    format!("Indirectly imported: {}", usage.name),
-                    usage.location.in_file(&parsed.original_path),
-                    None,
-                ),
-                _ => (),
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn get_scope<'a>(
-    file: &'a Path,
-    files: &'a Map<PathBuf, Parsed>,
-    scopes: &mut Map<&'a Path, ScopeWip<'a>>,
-) -> Result<Scope<'a>, Error> {
-    match scopes.get(file) {
-        Some(ScopeWip::Current) => bail!("Recursive import of {}", file.display()),
-        Some(ScopeWip::Resolved(scope)) => return Ok(scope.clone()),
-        _ => (),
-    };
-    scopes.insert(file, ScopeWip::Current);
-
-    let parsed_file = files.get(file).ok_or_else(|| {
-        format_err!(
-            "List of elements in scope of file {} was requested, \
-             but not available due to previous import error",
-            file.display()
-        )
-    })?;
-
-    let mut scope = Scope::default();
-
-    for import in &parsed_file.imports {
-        let nested = get_scope(&import, files, scopes)?;
-        scope.directly_imported.extend(&nested.defined);
-        scope.all.extend(&nested.all);
-        scope.files.extend(&nested.files);
-    }
-
-    for definition in &parsed_file.definitions {
-        scope.defined.insert(&definition.name);
-        scope.all.insert(&definition.name);
-    }
-
-    scope.files.insert(file);
-
-    scopes.insert(file, ScopeWip::Resolved(scope.clone()));
-
-    Ok(scope)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate failure;
 extern crate lazy_static;
 
 mod syntax;
+mod preprocess;
 
 use walkdir::WalkDir;
 
@@ -14,14 +15,17 @@ use failure::ResultExt;
 
 use std::collections::BTreeMap as Map;
 use std::collections::BTreeSet as Set;
-use std::fs;
 use std::path::{Path, PathBuf};
+
+use preprocess::Parsed;
 
 pub fn run(root_path: impl AsRef<Path>, emitter: &mut Emitter) -> Result<(), Error> {
     run_(root_path.as_ref(), emitter)
 }
 
 fn run_(root_path: &Path, emitter: &mut Emitter) -> Result<(), Error> {
+    use preprocess::PreprocessOutput;
+
     let mut files = Map::new();
 
     for entry in WalkDir::new(root_path) {
@@ -36,7 +40,7 @@ fn run_(root_path: &Path, emitter: &mut Emitter) -> Result<(), Error> {
             continue;
         }
 
-        match parse_and_preprocess(entry.path(), emitter)? {
+        match preprocess::parse_and_preprocess(entry.path(), emitter)? {
             PreprocessOutput::Valid(parsed) => {
                 let path = entry.path().canonicalize()?;
                 files.insert(path, parsed);
@@ -137,125 +141,6 @@ impl Emitter for VecEmitter {
         let to_emit = EmittedItem { kind, message, location, notes };
         self.emitted_items.push(to_emit)
     }
-}
-
-// ---- Preprocessing --------------------------------------------------------
-
-/// Parsed and preprocessed source file
-#[derive(Debug)]
-struct Parsed {
-    imports: Vec<PathBuf>,
-    definitions: Vec<syntax::Definition>,
-    usages: Vec<syntax::Usage>,
-
-    /// Original, non-resolved path, relative to PWD
-    original_path: PathBuf,
-}
-
-#[derive(Debug)]
-enum PreprocessOutput {
-    /// Parsed and preprocessed file
-    Valid(Parsed),
-
-    /// A file can't be preprocessed since it contains invalid imports
-    InvalidImports,
-}
-
-/// Parses and preprocesses a file for further analysys.
-fn parse_and_preprocess(path: &Path, emitter: &mut Emitter) -> Result<PreprocessOutput, Error> {
-    let source = fs::read_to_string(path)?;
-    let file = syntax::parse(&source);
-
-    for testcase in file.testcases {
-        let invalid_chars: &[char] = &['"', '>', '<', '|', ':', '*', '?', '\\', '/'];
-
-        if file.uses_pester_logger && testcase.name.contains(invalid_chars) {
-            emitter.emit(
-                Message::Warning,
-                "Testname contains invalid characters".to_owned(),
-                testcase.location.in_file(path),
-                Some(format!(
-                    "These characters are invalid in a file name: {:?}",
-                    invalid_chars,
-                )),
-            );
-        }
-    }
-
-    let resolved_imports = match resolve_imports(path, file.imports, emitter)? {
-        Some(imports) => imports,
-        None => return Ok(PreprocessOutput::InvalidImports),
-    };
-
-    Ok(PreprocessOutput::Valid(Parsed {
-        imports: resolved_imports,
-        definitions: file.definitions,
-        usages: file.usages,
-        original_path: path.to_owned(),
-    }))
-}
-
-/// Verifies imports and canonicalizes their paths
-///
-/// Returns None if any of imports were not recognized
-fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &mut Emitter)
-    -> Result<Option<Vec<PathBuf>>, Error>
-{
-    let mut import_error = false;
-    let mut resolved_imports = Vec::new();
-
-    for import in imports {
-        use syntax::Importee;
-
-        let dir = source_path.parent().unwrap();
-        let filename = source_path.file_name().unwrap().to_str().unwrap();
-
-        let dest_path = match import.importee {
-            Importee::Relative(relative_path) => dir.join(relative_path),
-            Importee::HereSut => dir.join(filename.replace(".Tests", "")),
-            Importee::Unrecognized(_) => {
-                // Should we treat unrecognized import as an error also?
-                // This will stop processing the file further and will result in
-                // less spammy output, because we'll probably get some
-                // "Not in scope" errors later on.
-                // import_error = true;
-
-                emitter.emit(
-                    Message::Warning,
-                    "Unrecognized import statement".to_string(),
-                    import.location.in_file(source_path),
-                    Some(
-                        "Note: Recognized imports are `$PSScriptRoot\\..` or `$here\\$sut`"
-                            .to_string(),
-                    ),
-                );
-
-                continue;
-            }
-        };
-
-        if dest_path.exists() {
-            resolved_imports.push(dest_path.canonicalize()?)
-        } else {
-            import_error = true;
-
-            emitter.emit(
-                Message::Error,
-                "Invalid import".to_string(),
-                import.location.in_file(source_path),
-                Some(format!(
-                    "File not found: {}",
-                    dest_path.display()
-                )),
-            );
-        }
-    }
-
-    if import_error {
-        return Ok(None)
-    }
-
-    Ok(Some(resolved_imports))
 }
 
 // ---- Scope analysis -------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,14 @@
 extern crate shelly;
 
-use std::path::{Path, PathBuf};
-
 extern crate failure;
 use failure::Error;
 
 extern crate yansi;
 use yansi::{Color, Paint};
+
+use std::path::Path;
+
+use shelly::Location;
 
 fn main() {
     // Main is a thin wrapper around `run` designed to
@@ -41,16 +43,15 @@ impl shelly::Emitter for CliEmitter {
         &mut self,
         kind: shelly::Message,
         message: String,
-        file: PathBuf,
-        line_no: u32,
-        line: String,
+        location: Location,
         notes: Option<String>,
     ) {
         // Style of error message inspired by Rust
 
+        let line = location.line.line;
         let blue = Color::Blue.style().bold();
         let pipe = blue.paint("|");
-        let line_no = line_no.to_string();
+        let line_no = location.line.no.to_string();
         let offset = || {
             for _ in 0..line_no.len() {
                 print!(" ")
@@ -69,7 +70,7 @@ impl shelly::Emitter for CliEmitter {
         }
 
         offset();
-        println!("{} {}", blue.paint("-->"), file.display());
+        println!("{} {}", blue.paint("-->"), location.file.display());
 
         offset();
         println!(" {}", pipe);

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -1,0 +1,126 @@
+use failure::Error;
+
+use std::path::{Path, PathBuf};
+use std::fs;
+
+use syntax;
+use Emitter;
+use Message;
+
+/// Parsed and preprocessed source file
+#[derive(Debug)]
+pub struct Parsed {
+    pub imports: Vec<PathBuf>,
+    pub definitions: Vec<syntax::Definition>,
+    pub usages: Vec<syntax::Usage>,
+
+    /// Original, non-resolved path, relative to PWD
+    pub original_path: PathBuf,
+}
+
+#[derive(Debug)]
+pub enum PreprocessOutput {
+    /// Parsed and preprocessed file
+    Valid(Parsed),
+
+    /// A file can't be preprocessed since it contains invalid imports
+    InvalidImports,
+}
+
+/// Parses and preprocesses a file for further analysys.
+pub fn parse_and_preprocess(path: &Path, emitter: &mut Emitter) -> Result<PreprocessOutput, Error> {
+    let source = fs::read_to_string(path)?;
+    let file = syntax::parse(&source);
+
+    for testcase in file.testcases {
+        let invalid_chars: &[char] = &['"', '>', '<', '|', ':', '*', '?', '\\', '/'];
+
+        if file.uses_pester_logger && testcase.name.contains(invalid_chars) {
+            emitter.emit(
+                Message::Warning,
+                "Testname contains invalid characters".to_owned(),
+                testcase.location.in_file(path),
+                Some(format!(
+                    "These characters are invalid in a file name: {:?}",
+                    invalid_chars,
+                )),
+            );
+        }
+    }
+
+    let resolved_imports = match resolve_imports(path, file.imports, emitter)? {
+        Some(imports) => imports,
+        None => return Ok(PreprocessOutput::InvalidImports),
+    };
+
+    Ok(PreprocessOutput::Valid(Parsed {
+        imports: resolved_imports,
+        definitions: file.definitions,
+        usages: file.usages,
+        original_path: path.to_owned(),
+    }))
+}
+
+/// Verifies imports and canonicalizes their paths
+///
+/// Returns None if any of imports were not recognized
+fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &mut Emitter)
+    -> Result<Option<Vec<PathBuf>>, Error>
+{
+    let mut import_error = false;
+    let mut resolved_imports = Vec::new();
+
+    for import in imports {
+        use syntax::Importee;
+
+        let dir = source_path.parent().unwrap();
+        let filename = source_path.file_name().unwrap().to_str().unwrap();
+
+        let dest_path = match import.importee {
+            Importee::Relative(relative_path) => dir.join(relative_path),
+            Importee::HereSut => dir.join(filename.replace(".Tests", "")),
+            Importee::Unrecognized(_) => {
+                // Should we treat unrecognized import as an error also?
+                // This will stop processing the file further and will result in
+                // less spammy output, because we'll probably get some
+                // "Not in scope" errors later on.
+                // import_error = true;
+
+                emitter.emit(
+                    Message::Warning,
+                    "Unrecognized import statement".to_string(),
+                    import.location.in_file(source_path),
+                    Some(
+                        "Note: Recognized imports are `$PSScriptRoot\\..` or `$here\\$sut`"
+                            .to_string(),
+                    ),
+                );
+
+                continue;
+            }
+        };
+
+        if dest_path.exists() {
+            resolved_imports.push(dest_path.canonicalize()?)
+        } else {
+            import_error = true;
+
+            emitter.emit(
+                Message::Error,
+                "Invalid import".to_string(),
+                import.location.in_file(source_path),
+                Some(format!(
+                    "File not found: {}",
+                    dest_path.display()
+                )),
+            );
+        }
+    }
+
+    if import_error {
+        return Ok(None)
+    }
+
+    Ok(Some(resolved_imports))
+}
+

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,0 +1,149 @@
+use failure::Error;
+
+use std::collections::BTreeMap as Map;
+use std::collections::BTreeSet as Set;
+use std::path::{Path, PathBuf};
+
+use Emitter;
+use Message;
+use preprocess::Parsed;
+use is_allowed;
+
+/// Functions in scope
+#[derive(Debug, Clone, Default)]
+struct Scope<'a> {
+    /// Functions defined in this scopeanalyze
+    defined: Set<&'a str>,
+    /// Defined by a file imported by `analyze
+    directly_imported: Set<&'a str>,
+    /// All the functions in scope
+    all: Set<&'a str>,
+    /// All the files imported (directlanalyzely)
+    files: Set<&'a Path>,
+}
+
+/// Type of function found in scope
+#[derive(Debug)]
+enum Found {
+    /// Found in Scope::defined or Scope::indirectly_imported
+    Direct,
+    /// Indirectly imported (through multiple layers of `.`)
+    Indirect,
+}
+
+impl<'a> Scope<'a> {
+    fn search(&self, name: &str) -> Option<Found> {
+        if self.all.contains(name) {
+            if self.defined.contains(name) || self.directly_imported.contains(name) {
+                Some(Found::Direct)
+            } else {
+                Some(Found::Indirect)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// State of scope computation
+#[derive(Debug, Clone)]
+enum ScopeWip<'a> {
+    /// Done
+    Resolved(Scope<'a>),
+
+    /// The scope is being currently computed
+    /// (used to detect import loop)
+    Current,
+}
+
+pub fn analyze(files: &Map<PathBuf, Parsed>, emitter: &mut Emitter) -> Result<(), Error> {
+    lazy_static! {
+        static ref BUILTINS: Set<&'static str> = include_str!("builtins.txt")
+            .split_whitespace()
+            .chain(include_str!("extras.txt").split_whitespace())
+            .collect();
+    }
+
+    let mut scopes = Map::new();
+
+    for path in files.keys() {
+        let scope = get_scope(path, files, &mut scopes)?;
+
+        let parsed = &files[path];
+
+        let mut already_analyzed = Set::new();
+
+        for usage in &parsed.usages {
+            if BUILTINS.contains(usage.name.as_str()) {
+                continue;
+            }
+            if is_allowed(&usage.location.line, &usage.name) {
+                continue;
+            }
+            if already_analyzed.contains(usage.name.as_str()) {
+                continue;
+            }
+
+            already_analyzed.insert(usage.name.as_str());
+
+            match scope.search(&usage.name) {
+                None => emitter.emit(
+                    Message::Error,
+                    format!("Not in scope: {}", usage.name),
+                    usage.location.in_file(&parsed.original_path),
+                    None,
+                ),
+                Some(Found::Indirect) => emitter.emit(
+                    Message::Warning,
+                    format!("Indirectly imported: {}", usage.name),
+                    usage.location.in_file(&parsed.original_path),
+                    None,
+                ),
+                _ => (),
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_scope<'a>(
+    file: &'a Path,
+    files: &'a Map<PathBuf, Parsed>,
+    scopes: &mut Map<&'a Path, ScopeWip<'a>>,
+) -> Result<Scope<'a>, Error> {
+    match scopes.get(file) {
+        Some(ScopeWip::Current) => bail!("Recursive import of {}", file.display()),
+        Some(ScopeWip::Resolved(scope)) => return Ok(scope.clone()),
+        _ => (),
+    };
+    scopes.insert(file, ScopeWip::Current);
+
+    let parsed_file = files.get(file).ok_or_else(|| {
+        format_err!(
+            "List of elements in scope of file {} was requested, \
+             but not available due to previous import error",
+            file.display()
+        )
+    })?;
+
+    let mut scope = Scope::default();
+
+    for import in &parsed_file.imports {
+        let nested = get_scope(&import, files, scopes)?;
+        scope.directly_imported.extend(&nested.defined);
+        scope.all.extend(&nested.all);
+        scope.files.extend(&nested.files);
+    }
+
+    for definition in &parsed_file.definitions {
+        scope.defined.insert(&definition.name);
+        scope.all.insert(&definition.name);
+    }
+
+    scope.files.insert(file);
+
+    scopes.insert(file, ScopeWip::Resolved(scope.clone()));
+
+    Ok(scope)
+}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,0 +1,159 @@
+use failure::Error;
+use regex::Regex;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use Emitter;
+use Message;
+
+/// A `.` import
+#[derive(Debug)]
+pub struct Import {
+    pub line: String,
+    pub line_no: u32,
+    pub resolved_path: PathBuf,
+}
+
+/// Function / commandlet definition
+#[derive(Debug)]
+pub struct Definition {
+    pub line: String,
+    pub line_no: u32,
+    pub name: String,
+}
+
+/// Function / commandlet call
+#[derive(Debug)]
+pub struct Usage {
+    pub line: String,
+    pub line_no: u32,
+    pub name: String,
+}
+
+/// Parsed source file
+#[derive(Debug)]
+pub struct Parsed {
+    pub imports: Vec<Import>,
+    pub definitions: Vec<Definition>,
+    pub usages: Vec<Usage>,
+
+    /// Original, non-resolved path, relative to PWD
+    pub original_path: PathBuf,
+}
+
+/// Reads and parses source file
+pub fn parse(path: &Path, emitter: &mut Emitter) -> Result<Parsed, Error> {
+    lazy_static! {
+        static ref IMPORT: Regex = Regex::new(
+            r"(?ix) ^ \s* \. \s+ (.*?) \s* (\#.*)? $"
+        ).unwrap();
+
+        static ref IMPORT_RELATIVE: Regex = Regex::new(
+            r"(?ix) ^ \$ PSScriptRoot (.*?) $"
+        ).unwrap();
+
+        static ref IMPORT_HERESUT: Regex = Regex::new(
+            r#"(?ix) ^ ["]? \$ here [/\\] \$ sut ["]? $"#
+        ).unwrap();
+
+        // Note: it captures also definitions of nested functions,
+        // so it's overly optimistic wrt. code correctness.
+        static ref DEFINITION: Regex = Regex::new(
+            r"(?ix) ^ \s* function \s+ ([a-z][a-z0-9-]*) .* $"
+        ).unwrap();
+
+        // For now, conservatively treat only [$x = ] Verb-Foo
+        // at the very beginning of line as usage.
+        static ref USAGE: Regex = Regex::new(
+            r"(?ix) ^ \s* (?: \$\S+ \s*=\s*)? ([[:alpha:]]+-[a-z0-9]+) (?: \s+ .*)? $"
+        ).unwrap();
+
+        static ref TESTCASE: Regex = Regex::new(
+            r#"(?ix) ^ \s* It \s+ " ([^"]*) " "#
+        ).unwrap();
+    }
+
+    let file = fs::read_to_string(path)?;
+
+    // Strip BOM
+    let file = file.trim_left_matches('\u{feff}');
+
+    let mut definitions = Vec::new();
+    let mut usages = Vec::new();
+    let mut imports = Vec::new();
+
+    let uses_pester_logger = file.contains("Initialize-PesterLogger");
+
+    for (line, line_no) in file.lines().zip(1..) {
+        if let Some(captures) = IMPORT.captures(line) {
+            let importee = &captures[1];
+            let resolved_path = if let Some(captures) = IMPORT_RELATIVE.captures(importee) {
+                let relative = captures[1].replace(r"\", "/");
+                let relative = relative.trim_matches('/');
+                path.parent().unwrap().join(relative)
+            } else if IMPORT_HERESUT.is_match(importee) {
+                let pathstr = path.to_str().unwrap();
+                pathstr.replace(".Tests.", ".").into()
+            } else {
+                emitter.emit(
+                    Message::Warning,
+                    "Unrecognized import statement".to_string(),
+                    PathBuf::from(path),
+                    line_no,
+                    line.to_string(),
+                    Some(
+                        "Note: Recognized imports are `$PSScriptRoot\\..` or `$here\\$sut`"
+                            .to_string(),
+                    ),
+                );
+                continue;
+            };
+            imports.push(Import {
+                line: line.to_owned(),
+                resolved_path,
+                line_no,
+            })
+        }
+
+        if let Some(captures) = DEFINITION.captures(line) {
+            definitions.push(Definition {
+                line: line.to_owned(),
+                line_no,
+                name: captures[1].to_owned(),
+            });
+        }
+
+        if let Some(captures) = USAGE.captures(line) {
+            usages.push(Usage {
+                line: line.to_owned(),
+                line_no,
+                name: captures[1].to_owned(),
+            });
+        }
+
+        if let Some(captures) = TESTCASE.captures(line) {
+            let invalid_chars: &[char] = &['"', '>', '<', '|', ':', '*', '?', '\\', '/'];
+            if uses_pester_logger && captures[1].contains(invalid_chars) {
+                emitter.emit(
+                    Message::Warning,
+                    "Testname contains invalid characters".to_owned(),
+                    path.to_owned(),
+                    line_no,
+                    line.to_owned(),
+                    Some(format!(
+                        "These characters are invalid in a file name: {:?}",
+                        invalid_chars
+                    )),
+                );
+            }
+        }
+    }
+
+    Ok(Parsed {
+        definitions,
+        usages,
+        imports,
+        original_path: path.to_owned(),
+    })
+}

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -59,8 +59,8 @@ pub struct Testcase {
     pub name: String,
 }
 
-/// Reads and parses source file
-pub fn parse(file: &str) -> File {
+/// Parses a source file
+pub fn parse(source: &str) -> File {
     lazy_static! {
         static ref IMPORT: Regex = Regex::new(
             r"(?ix) ^ \s* \. \s+ (.*?) \s* (\#.*)? $"
@@ -92,16 +92,16 @@ pub fn parse(file: &str) -> File {
     }
 
     // Strip BOM
-    let file = file.trim_left_matches('\u{feff}');
+    let source = source.trim_left_matches('\u{feff}');
 
     let mut definitions = Vec::new();
     let mut usages = Vec::new();
     let mut imports = Vec::new();
     let mut testcases = Vec::new();
 
-    let uses_pester_logger = file.contains("Initialize-PesterLogger");
+    let uses_pester_logger = source.contains("Initialize-PesterLogger");
 
-    for (line, line_no) in file.lines().zip(1..) {
+    for (line, line_no) in source.lines().zip(1..) {
 
         let get_location = || Line { line: line.to_owned(), no: line_no };
 


### PR DESCRIPTION
cc @m-kostrzewa 
The actual refactors are done in the second commit, the rest are just shuffling code back and forth.

`lib.rs` now has three child modules: `syntax`, `preprocess` and `scope`, all of them but `preprocess` pure!

The `syntax` module is an independent one and the plan is to make it a separate crate (probably after implementing actual parser).