### PR TITLE
Initial changes for detecting unused imports.

### DIFF
--- a/src/lint.rs
+++ b/src/lint.rs
@@ -103,6 +103,9 @@ lints!{
 
     /// Shelly couldn't parse this syntax
     SyntaxErrors: "syntax-errors" => Warn,
+
+    /// File was imported but no direct definitions from it are being uesd
+    UnusedImports: "unused-imports" => Deny,
 }
 
 impl fmt::Display for UnknownLint {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -104,7 +104,7 @@ lints!{
     /// Shelly couldn't parse this syntax
     SyntaxErrors: "syntax-errors" => Warn,
 
-    /// File was imported but no direct definitions from it are being uesd
+    /// File was imported but no direct definitions from it are being used
     UnusedImports: "unused-imports" => Deny,
 }
 

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -105,7 +105,7 @@ lints!{
     SyntaxErrors: "syntax-errors" => Warn,
 
     /// File was imported but no direct definitions from it are being used
-    UnusedImports: "unused-imports" => Deny,
+    UnusedImports: "unused-imports" => Warn,
 }
 
 impl fmt::Display for UnknownLint {

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -119,3 +119,17 @@ fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &m
     Ok(Some(resolved_imports))
 }
 
+impl Parsed {
+    pub fn functions(&self) -> impl Iterator<Item=&syntax::Definition> {
+        // Currently all definitions are functions, except the
+        // pseudoitems, whose names begin with `!`.
+        // Pseudoitems are items that are propaged similarly to normal
+        // definitions, but they're created by some part of analysis.
+        // Eg. we have "uses strict mode" pseudoitem, that gets injected
+        // on "Set-StrictMode" and propagates to downstream files.
+        self.definitions
+            .iter()
+            .filter(|def| !def.name.starts_with("!"))
+    }
+}
+

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -181,6 +181,20 @@ pub fn analyze<'a>(files: &'a Map<PathBuf, Parsed>, config: &ConfigFile, emitter
         // scope analysis to save some info.
         for (imported_file, import) in &parsed.imports {
             if !used_dependencies.contains(&**imported_file) {
+                if files[imported_file]
+                        .definitions
+                        .iter()
+                        .filter(|def| !def.name.starts_with("!")) // skip pseudoitems
+                        .next()
+                        .is_none()
+                {
+                    // Temporarily silence unused-imports for files with no functions
+                    // to avoid false positives.
+                    // TODO Make the parser understand the world beyound functions
+                    // and reenable the lint.
+                    continue;
+                }
+
                 import.location.in_file(&parsed.original_path)
                     .lint(
                         Lint::UnusedImports,

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -181,13 +181,7 @@ pub fn analyze<'a>(files: &'a Map<PathBuf, Parsed>, config: &ConfigFile, emitter
         // scope analysis to save some info.
         for (imported_file, import) in &parsed.imports {
             if !used_dependencies.contains(&**imported_file) {
-                if files[imported_file]
-                        .definitions
-                        .iter()
-                        .filter(|def| !def.name.starts_with("!")) // skip pseudoitems
-                        .next()
-                        .is_none()
-                {
+                if files[imported_file].functions().next().is_none() {
                     // Temporarily silence unused-imports for files with no functions
                     // to avoid false positives.
                     // TODO Make the parser understand the world beyond functions

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -190,7 +190,7 @@ pub fn analyze<'a>(files: &'a Map<PathBuf, Parsed>, config: &ConfigFile, emitter
                 {
                     // Temporarily silence unused-imports for files with no functions
                     // to avoid false positives.
-                    // TODO Make the parser understand the world beyound functions
+                    // TODO Make the parser understand the world beyond functions
                     // and reenable the lint.
                     continue;
                 }

--- a/src/strictness.rs
+++ b/src/strictness.rs
@@ -35,13 +35,8 @@ pub fn analyze<'a>(
     let mut importees: Set<&Path> = Set::new();
 
     for parsed in files.values() {
-        for importee in &parsed.imports {
-            match &importee.resolved_import {
-                None => (),
-                Some(res) => {
-                    importees.insert(res);
-                }
-            }
+        for importee in parsed.imports.keys() {
+            importees.insert(importee);
         }
     }
 

--- a/src/strictness.rs
+++ b/src/strictness.rs
@@ -36,7 +36,12 @@ pub fn analyze<'a>(
 
     for parsed in files.values() {
         for importee in &parsed.imports {
-            importees.insert(importee);
+            match &importee.resolved_import {
+                None => (),
+                Some(res) => {
+                    importees.insert(res);
+                }
+            }
         }
     }
 

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::cmp::Ordering;
 
 use regex::Regex;
 
@@ -26,21 +25,9 @@ pub struct Line {
 /// A `.` import
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Import {
-    pub resolved_import: Option<PathBuf>,
     pub location: Line,
     pub importee: Importee,
 }
-impl Ord for Import {
-    fn cmp(&self, other: &Import) -> Ordering {
-        self.location.no.cmp(&other.location.no)
-    }
-}
-impl PartialOrd for Import {
-    fn partial_cmp(&self, other: &Import) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 
 /// An importee pointed by `.` import
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -156,7 +143,6 @@ pub fn parse(source: &str, debug: bool) -> Result<File> {
             };
 
             imports.push(Import {
-                resolved_import: None,
                 location: get_location(),
                 importee,
             })


### PR DESCRIPTION
Ran it on contrail-windows-ci repo, found a bunch of false positives: https://gist.github.com/m-kostrzewa/5bad3112320bf0c63d0012bc137c9567

False positives mainly for files that import files without defined functions (like Init.ps1) or with classes only (like Job.ps1).

Not sure how to handle either of those scenarios with current Shelly implementation, since it only handles functions for now - not classes or files without functions. Asking the user to specify `allow unused-imports` for all these files is too cumbersome IMO.

Suggested workaround: don't raise unused-imports, if file has no function definitions. This may create false negatives or whatever for unused classes.

@krdln thoughts?