### PR TITLE
Teach shelly about classes

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -121,15 +121,9 @@ fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &m
 
 impl Parsed {
     pub fn functions(&self) -> impl Iterator<Item=&syntax::Definition> {
-        // Currently all definitions are functions, except the
-        // pseudoitems, whose names begin with `!`.
-        // Pseudoitems are items that are propaged similarly to normal
-        // definitions, but they're created by some part of analysis.
-        // Eg. we have "uses strict mode" pseudoitem, that gets injected
-        // on "Set-StrictMode" and propagates to downstream files.
         self.definitions
             .iter()
-            .filter(|def| !def.name.starts_with("!"))
+            .filter(|def| def.item.is_function())
     }
 }
 

--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -120,10 +120,10 @@ fn resolve_imports(source_path: &Path, imports: Vec<syntax::Import>, emitter: &m
 }
 
 impl Parsed {
-    pub fn functions(&self) -> impl Iterator<Item=&syntax::Definition> {
+    pub fn functions_and_classes(&self) -> impl Iterator<Item=&syntax::Definition> {
         self.definitions
             .iter()
-            .filter(|def| def.item.is_function())
+            .filter(|def| def.item.is_function() || def.item.is_class())
     }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -11,19 +11,18 @@ use lint::Lint;
 use preprocess::Parsed;
 use ConfigFile;
 
-struct Config {
-    custom_cmdlets: Set<UniCase<String>>,
+struct Config<'a> {
+    custom_cmdlets: Set<UniCase<&'a str>>,
 }
 
-impl Config {
+impl<'a> Config<'a> {
     fn from_config_file(config_file: &ConfigFile) -> Config {
         let custom_cmdlets = config_file.extras.as_ref()
             .and_then(|extras| extras.cmdlets.as_ref())
             .map(|cmdlets|
                 cmdlets
                     .iter()
-                    .cloned()
-                    .map(|cmdlet| UniCase::new(cmdlet))
+                    .map(|cmdlet| UniCase::new(cmdlet.as_str()))
                     .collect()
             )
             .unwrap_or_else(Set::new);
@@ -120,7 +119,7 @@ pub fn analyze<'a>(files: &'a Map<PathBuf, Parsed>, config: &ConfigFile, emitter
             if BUILTINS.contains(&UniCase::new(&usage.name)) {
                 continue;
             }
-            if config.custom_cmdlets.contains(&UniCase::new(usage.name.clone())) {
+            if config.custom_cmdlets.contains(&UniCase::new(&usage.name)) {
                 continue;
             }
             if already_analyzed.contains(&UniCase::new(&usage.name)) {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -187,9 +187,9 @@ pub fn analyze<'a>(files: &'a Map<PathBuf, Parsed>, config: &ConfigFile, emitter
         // scope analysis to save some info.
         for (imported_file, import) in &parsed.imports {
             if !used_dependencies.contains(&**imported_file) {
-                if files[imported_file].functions().next().is_none() {
-                    // Temporarily silence unused-imports for files with no functions
-                    // to avoid false positives.
+                if files[imported_file].functions_and_classes().next().is_none() {
+                    // Temporarily silence unused-imports for weird "empty" files
+                    // with no functions and no class definitions to avoid false positives.
                     // TODO Make the parser understand the world beyond functions
                     // and reenable the lint.
                     continue;

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -99,6 +99,7 @@ impl<S: AsRef<str>> Item<S> {
     }
 
     pub fn is_function(&self) -> bool { self.kind == ItemKind::Function }
+    pub fn is_class(&self) -> bool { self.kind == ItemKind::Class }
 
 }
 

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -158,7 +158,7 @@ pub fn parse(source: &str, debug: bool) -> Result<File> {
     let mut imports = Vec::new();
     let mut testcases = Vec::new();
 
-    v2::traverse_streams(&token_tree_stream, |stream| {
+    v2::traverse_streams(&token_tree_stream, |stream, _| {
         let mut is_function_definition = false;
         let mut iter = stream.iter();
         while let Some(tt) = iter.next() {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -283,6 +283,9 @@ fn test_basics() {
         Describe "something" {
             It "works" {}
         }
+
+        class Car {}
+        [Boat] $Foo = 5
     "#;
 
     let parsed = parse(source, false).unwrap();
@@ -295,10 +298,14 @@ fn test_basics() {
 
     assert_eq!(parsed.definitions[0].item.name, "Foo");
     assert_eq!(parsed.definitions[1].item.name, "Bar");
+    assert_eq!(parsed.definitions[2].item.as_ref(), Item::class("Car"));
 
     assert_eq!(parsed.usages[0].item.name, "Fooize-Bar");
     assert_eq!(parsed.usages[1].item.name, "Write-Host");
     assert_eq!(parsed.usages[2].item.name, "Write-Log");
+    assert_eq!(parsed.usages[3].item.as_ref(), Item::function("Describe"));
+    assert_eq!(parsed.usages[4].item.as_ref(), Item::function("It"));
+    assert_eq!(parsed.usages[5].item.as_ref(), Item::class("Boat"));
 
     assert_eq!(parsed.testcases[0].name, "works");
 }

--- a/src/syntax/v2/mod.rs
+++ b/src/syntax/v2/mod.rs
@@ -18,12 +18,13 @@
 
 mod muncher;
 use self::muncher::Muncher;
-use self::muncher::{Span, Location};
+pub use self::muncher::{Span, Location};
 
 mod stage1;
 mod stage2;
 pub use self::stage2::traverse_streams;
 pub use self::stage2::TokenTree;
+pub use self::stage2::Delimiter;
 
 mod stream;
 

--- a/src/syntax/v2/stage2.rs
+++ b/src/syntax/v2/stage2.rs
@@ -418,16 +418,20 @@ fn parse_variable_name(mut dollar_span: Option<Span>, stream: &mut Stream<TT1>, 
     }
 }
 
-pub fn traverse_streams(stream: &[TT], mut fun: impl FnMut(&[TT])) {
-    traverse_streams_(stream, &mut fun);
+pub fn traverse_streams(stream: &[TT], mut fun: impl FnMut(&[TT], Option<Delimiter>)) {
+    traverse_streams_(stream, None, &mut fun);
 }
 
-fn traverse_streams_(stream: &[TT], fun: &mut impl FnMut(&[TT])) {
-    fun(stream);
+fn traverse_streams_(
+    stream: &[TT],
+    delimiter: Option<Delimiter>,
+    fun: &mut impl FnMut(&[TT], Option<Delimiter>)
+) {
+    fun(stream, delimiter);
     for tt in stream.iter() {
         match tt {
-            TT::Group { interior, .. }            |
-            TT::String { subtrees: interior, .. } => traverse_streams_(interior, fun),
+            TT::Group { interior, delimiter, .. } => traverse_streams_(interior, Some(*delimiter), fun),
+            TT::String { subtrees, .. }           => traverse_streams_(subtrees, None, fun),
             _                                     => ()
         }
     }

--- a/src/testnames.rs
+++ b/src/testnames.rs
@@ -4,13 +4,14 @@ use std::path::PathBuf;
 use lint::Lint;
 use lint::Emitter;
 use preprocess::Parsed;
+use syntax::Item;
 
 pub fn analyze(files: &Map<PathBuf, Parsed>, emitter: &mut Emitter) {
     let invalid_chars: &[char] = &['"', '>', '<', '|', ':', '*', '?', '\\', '/'];
 
     for file in files.values() {
         let uses_pester_logger = file.usages.iter()
-            .any(|usage| usage.name == "Initialize-PesterLogger");
+            .any(|usage| usage.item.as_ref() == Item::function("Initialize-PesterLogger"));
 
         if !uses_pester_logger {
             continue;


### PR DESCRIPTION
At least a little bit.

cc @m-kostrzewa 

It will enable us to get rid of all but one `[Shelly-Bug]` in winci (the one remaining is actually a different one—unused-imports is firing because the only usage of function is through `Get-Item function:Something`).

Interestingly, this PR causes indirect-imports to fire a lot for—as you might guessed—indirectly imported classes.