### PR TITLE
Detect "import-bag" files and disable warnings sometimes

### DIFF
--- a/src/preprocess.rs
+++ b/src/preprocess.rs
@@ -149,5 +149,10 @@ impl Parsed {
             .iter()
             .filter(|def| def.item.is_function() || def.item.is_class())
     }
+
+    /// Whether this file contains only imports (no definitions nor usages)
+    pub fn is_import_bag(&self) -> bool {
+        self.functions_and_classes().next().is_none() && self.usages.is_empty()
+    }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -500,6 +500,8 @@ mod test {
             file_D: uses foo() ---/  /
                                     /
             file_E: uses nothing --/
+                    (except of builtin functions.
+                     TODO: Dont' detect never-imported files as import-bags and revert the test)
 
             We expect that:
             * file_B complains about unused import file_C and
@@ -526,6 +528,7 @@ mod test {
                 }),
             ( "file_E".into(), Parsed {
                     imports: collect![import("file_B")],
+                    usages: vec![usage("New-Item")],
                     ..Parsed::default()
                 }),
         ].into_iter().collect();
@@ -624,6 +627,7 @@ mod test {
                 "file_B".into(),
                 Parsed {
                     imports: collect![import("file_A")],
+                    usages: collect![usage("New-Item")],
                     ..Parsed::default()
                 }
             ),


### PR DESCRIPTION
Import bag is a file containing only imports.

* Don't emit indirect-imports when importing through import bag (that's the purpose of an import bag)
* Don't emit unused-imports inside such import bags

Partial fix for #24 